### PR TITLE
fix: read browser locale and is debug on first event

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptabase/angular",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Angular SDK for Aptabase: Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web Apps",
   "scripts": {
     "ng": "ng",

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Move browser locale and is debug reads from import to first event to better support SSR
+
 ## 0.1.1
 
 - Support for custom API path

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptabase/browser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Browser Extension SDK for Aptabase: Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web Apps",
   "main": "./dist/index.cjs",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- Move browser locale and is debug reads from import to first event to better support SSR
+
 ## 0.3.3
 
 - Rename `apiPath` to `apiUrl`

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptabase/react",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "description": "React SDK for Aptabase: Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web Apps",
   "main": "./dist/index.cjs",

--- a/packages/shared.ts
+++ b/packages/shared.ts
@@ -1,5 +1,5 @@
-const defaultLocale = getBrowserLocale();
-const defaultIsDebug = getIsDebug();
+let defaultLocale: string | undefined;
+let defaultIsDebug: boolean | undefined;
 const isInBrowser = typeof window !== 'undefined' && typeof window.fetch !== 'undefined';
 const isInBrowserExtension = typeof chrome !== 'undefined' && !!chrome.runtime?.id;
 
@@ -103,8 +103,8 @@ export async function sendEvent(opts: {
         sessionId: opts.sessionId,
         eventName: opts.eventName,
         systemProps: {
-          locale: opts.locale ?? defaultLocale,
-          isDebug: opts.isDebug ?? defaultIsDebug,
+          locale: opts.locale ?? getBrowserLocale(),
+          isDebug: opts.isDebug ?? getIsDebug(),
           appVersion: opts.appVersion ?? '',
           sdkVersion: opts.sdkVersion,
         },
@@ -123,25 +123,39 @@ export async function sendEvent(opts: {
 }
 
 function getBrowserLocale(): string | undefined {
+  if (defaultLocale) {
+    return defaultLocale;
+  }
+
   if (typeof navigator === 'undefined') {
     return undefined;
   }
 
   if (navigator.languages.length > 0) {
-    return navigator.languages[0];
+    defaultLocale = navigator.languages[0];
+  } else {
+    defaultLocale = navigator.language;
   }
 
-  return navigator.language;
+  return defaultLocale;
 }
 
 function getIsDebug(): boolean {
+  if (defaultIsDebug !== undefined) {
+    return defaultIsDebug;
+  }
+
   if (process.env['NODE_ENV'] === 'development') {
-    return true;
+    defaultIsDebug = true;
+    return defaultIsDebug;
   }
 
   if (typeof location === 'undefined') {
-    return false;
+    defaultIsDebug = false;
+    return defaultIsDebug;
   }
 
-  return location.hostname === 'localhost';
+  defaultIsDebug = location.hostname === 'localhost';
+
+  return defaultIsDebug;
 }

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+- Move browser locale and is debug reads from import to first event to better support SSR
+
 ## 0.4.2
 
 - Fix error when running on chrome

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptabase/web",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "JavaScript SDK for Aptabase: Open Source, Privacy-First and Simple Analytics for Mobile, Desktop and Web Apps",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
`shared.ts` currently reads the default browser locale and is debug on import, which causes issues when imported in a server component. This moves the reads for those to whenever the first event is sent and those values are actually required, which is typically on the client.

I changed `defaultIsDebug` to match the functionality because it could cause issues (even if it's changed in the future), so let me know if you want me to undo those. I just figure it should work similarly.

I also updated all the package versions and changelogs since the changed code was in `shared.ts`. Wasn't sure if I should but let me know if you need those reverted.

fix #7